### PR TITLE
Version 0.1.2

### DIFF
--- a/citools/compile_win_wheels_msys2.sh
+++ b/citools/compile_win_wheels_msys2.sh
@@ -94,7 +94,7 @@ export PYOOMPH_SHORTPYVERSION=$(echo $PYOOMPH_PYVERSION | cut -d . -f 1,2 | tr -
 export TAG=cp${PYOOMPH_SHORTPYVERSION}-win_amd64
 export WHEELTAG=cp${PYOOMPH_PYVERSION}-${TAG}
 CURRENT_PYTHON=$(readlink -f ./build/python.${PYOOMPH_PYVERSION}/tools/python.exe)
-$CURRENT_PYTHON  -m pip install wheel pybind11 setuptools
+$CURRENT_PYTHON  -m pip install wheel pybind11 setuptools --upgrade
 
 #if false; then ####TODO REMOVE####
 make -f citools/MakefileMSYS2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath('../../pyoomph'))
 project = 'pyoomph'
 copyright = '2024, Christian Diddens & Duarte Rocha'
 author = 'Christian Diddens & Duarte Rocha'
-release = '0.1.1'
+release = '0.1.2'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/tutorial/installation/pypa.rst
+++ b/docs/source/tutorial/installation/pypa.rst
@@ -54,8 +54,7 @@ On Mac, ``clang`` will be used as high performance compiler. To get ``clang``, i
 
 .. warning::
 
-   If you are using a recent Mac with the M1 processor (arm64 architecture), you must potentially downgrade the package ``mkl``.
-   To do so, enter in a Rosetta 2 terminal
+   If you are using a recent Mac with the M1 processor (arm64 architecture), make sure to not upgrade the package ``mkl``. Also on Macs with an Intel processor, more recent versions can cause a crash. If you by accident upgrade your mkl package, reset it by entering (in a Rosetta 2 terminal for M1 chips):
    
    .. code:: bash
    

--- a/docs/source/tutorial/installation/source/mac.rst
+++ b/docs/source/tutorial/installation/source/mac.rst
@@ -45,7 +45,7 @@ Before building pyoomph, we first have to make sure that additional python packa
 
 The ``python3`` command might be also ``python``, depending on the system. Be sure to use the more recent version of python.
 
-If your Mac has an M1 chip, do the following
+On Mac, make sure you have not upgraded your mkl package to the recent version, which actually crashes on Mac:
 
 .. code:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,19 @@
 [project]
 name = "pyoomph"
-version = "0.1.1"
+version = "0.1.2"
 description = "pyoomph - a multi-physics finite element framework based on oomph-lib and GiNaC"
-dependencies = ['meshio>=5.3.4', 'pygmsh>=7.1.17', 'numpy>=1.24.4', 'scipy>=1.10.1', 'matplotlib>=3.7.5', 'mkl>=2021.4.0', 'more_itertools>=10.2.0','tccbox>=2024.3.18','setuptools>=69.5.1']
+dependencies = [
+'meshio>=5.3.4', 
+'pygmsh>=7.1.17', 
+'numpy>=1.24.4', 
+'scipy>=1.10.1', 
+'matplotlib>=3.7.5', 
+'more_itertools>=10.2.0',
+'tccbox>=2024.3.18',
+'setuptools>=69.5.1',
+'mkl>=2021.4.0; sys_platform != "darwin"',
+'mkl==2021.4.0; sys_platform == "darwin"'
+]
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [  { name="Christian Diddens", email="c.diddens@utwente.nl" },  { name="Duarte Rocha", email="d.rocha@utwente.nl" },  ]

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ else:
   if no_mpi_indicator_file.exists():    
      no_mpi_indicator_file.unlink()
      
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 
 class get_pybind_include(object):
@@ -265,6 +265,7 @@ ParallelCompile("NPY_NUM_BUILD_JOBS",default=4).install()
 
 setup(
     name='pyoomph',
+    version=__version__,
 		packages=create_package_list('pyoomph')+["_pyoomph-stubs"],
     ext_modules=ext_modules,
     setup_requires=['pybind11>=2.5.0'],


### PR DESCRIPTION
MKL automatic installation on Mac takes a recent version which crashes
Automatic downgrade now on all Macs.