### PR TITLE
install on MXXX Macs

### DIFF
--- a/installOnArm.sh
+++ b/installOnArm.sh
@@ -1,0 +1,501 @@
+#!/bin/bash
+
+# pyoomph ARM64 Native Installation Script - Fixed Version
+# This script attempts to build pyoomph natively on Apple Silicon (ARM64)
+# without requiring Rosetta 2
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== pyoomph ARM64 Native Installation ===${NC}"
+echo -e "${YELLOW}Warning: This is an experimental build for ARM64 architecture${NC}"
+echo ""
+
+# Function to check if running on ARM64
+check_architecture() {
+    if [[ $(uname -m) != "arm64" ]]; then
+        echo -e "${RED}Error: This script is designed for ARM64 architecture only${NC}"
+        echo "Detected architecture: $(uname -m)"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ ARM64 architecture detected${NC}"
+}
+
+# Function to check dependencies
+check_dependencies() {
+    echo -e "\n${BLUE}Checking dependencies...${NC}"
+    
+    # Check for Homebrew
+    if ! command -v brew &> /dev/null; then
+        echo -e "${RED}Error: Homebrew is required but not installed${NC}"
+        echo "Install from: https://brew.sh"
+        exit 1
+    fi
+    
+    # Check for Python 3
+    if ! command -v python3 &> /dev/null; then
+        echo -e "${RED}Error: Python 3 is required but not installed${NC}"
+        exit 1
+    fi
+    
+    echo -e "${GREEN}✓ Basic dependencies satisfied${NC}"
+}
+
+# Function to install system dependencies
+install_system_deps() {
+    echo -e "\n${BLUE}Installing system dependencies via Homebrew...${NC}"
+    
+    # Install required packages
+    brew install openmpi ccache ginac openblas lapack gmp cln || {
+        echo -e "${YELLOW}Some packages may already be installed, continuing...${NC}"
+    }
+    
+    echo -e "${GREEN}✓ System dependencies installed${NC}"
+}
+
+# Function to create Python environment
+setup_python_env() {
+    echo -e "\n${BLUE}Setting up Python environment...${NC}"
+    
+    # Create virtual environment
+    if [ -d "py-oomph" ]; then
+        echo -e "${YELLOW}Virtual environment 'py-oomph' already exists${NC}"
+        read -p "Remove and recreate? (y/N): " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            rm -rf py-oomph
+            python3 -m venv py-oomph
+        fi
+    else
+        python3 -m venv py-oomph
+    fi
+    
+    # Activate environment
+    source py-oomph/bin/activate
+    
+    # Upgrade pip
+    pip install --upgrade pip
+    
+    echo -e "${GREEN}✓ Python environment ready${NC}"
+}
+
+# Function to modify setup.py for ARM64
+modify_setup_py() {
+    echo -e "\n${BLUE}Creating ARM64-compatible setup.py...${NC}"
+    
+    # Backup pyproject.toml before modifying it
+    cp pyproject.toml pyproject.toml.original
+    
+    # Create modified pyproject.toml without MKL for ARM64
+    python3 << 'EOF'
+import re
+
+# Read original pyproject.toml
+with open('pyproject.toml', 'r') as f:
+    content = f.read()
+
+# Remove MKL dependencies
+# Remove both lines with mkl
+content = re.sub(r"'mkl>=2021\.4\.0; sys_platform != \"darwin\"',?\s*\n", "", content)
+content = re.sub(r"'mkl==2021\.4\.0; sys_platform == \"darwin\"',?\s*\n", "", content)
+
+# Clean up any trailing comma from the previous line
+content = re.sub(r",(\s*\])", r"\1", content)
+
+# Write modified version
+with open('pyproject.toml', 'w') as f:
+    f.write(content)
+
+print("Modified pyproject.toml to remove MKL dependencies")
+EOF
+    
+    # Create modified version
+    cat > setup_arm64.py << 'EOF'
+import os
+import sys
+import subprocess
+from setuptools import setup, Extension, find_packages
+from setuptools.command.build_ext import build_ext
+
+# Read the original setup.py
+with open('setup.py', 'r') as f:
+    original_content = f.read()
+
+# Function to modify install_requires
+def get_arm64_requirements():
+    """Get requirements suitable for ARM64, excluding MKL"""
+    base_requires = [
+        "numpy",
+        "scipy",
+        "matplotlib", 
+        "pygmsh",
+        "meshio",
+        "gmsh",
+        "pybind11",
+        "PyParsing",
+        "Pillow",
+        "Pygments",
+        "pybind11-stubgen",
+        "more-itertools"
+    ]
+    
+    # Add optional dependencies that work on ARM64
+    optional = [
+        "mpi4py",
+        "petsc4py",
+    ]
+    
+    return base_requires + optional
+
+# Monkey patch to use OpenBLAS instead of MKL
+os.environ['PYOOMPH_USE_OPENBLAS'] = '1'
+os.environ['PYOOMPH_NO_MKL'] = '1'
+
+# Execute modified setup
+exec(original_content.replace(
+    '"mkl"',  # Remove MKL from requirements
+    '# "mkl" # Disabled for ARM64'
+))
+EOF
+    
+    echo -e "${GREEN}✓ Modified setup.py created${NC}"
+    echo -e "${GREEN}✓ Modified pyproject.toml to remove MKL${NC}"
+}
+
+# Function to create build configuration
+create_build_config() {
+    echo -e "\n${BLUE}Creating ARM64 build configuration...${NC}"
+    
+    # Create custom config
+    cat > pyoomph_config_arm64.env << 'EOF'
+# ARM64 Native Build Configuration
+PYOOMPH_MARCH_NATIVE=false
+PYOOMPH_NO_TCC=true
+PYOOMPH_USE_OPENBLAS=true
+PYOOMPH_NO_MKL=true
+PYOOMPH_CONFIG_FILE=pyoomph_config_arm64.env
+
+# Compiler settings
+CXX=g++
+CC=gcc
+CXXFLAGS=-O3 -fPIC -std=c++11
+LDFLAGS=-L/opt/homebrew/lib
+CPPFLAGS=-I/opt/homebrew/include
+
+# OpenBLAS settings
+OPENBLAS_NUM_THREADS=1
+BLAS_LIBS=-lopenblas
+LAPACK_LIBS=-llapack
+
+# MPI settings (if using MPI)
+PYOOMPH_USE_MPI=auto
+EOF
+    
+    # Export these for current session
+    export PYOOMPH_MARCH_NATIVE=false
+    export PYOOMPH_NO_TCC=true
+    export PYOOMPH_USE_OPENBLAS=true
+    export PYOOMPH_NO_MKL=true
+    export OPENBLAS_NUM_THREADS=1
+    
+    # Set OpenBLAS paths for scipy build
+    export LDFLAGS="-L/opt/homebrew/opt/openblas/lib -L/opt/homebrew/opt/lapack/lib"
+    export CPPFLAGS="-I/opt/homebrew/opt/openblas/include -I/opt/homebrew/opt/lapack/include"
+    export PKG_CONFIG_PATH="/opt/homebrew/opt/openblas/lib/pkgconfig:/opt/homebrew/opt/lapack/lib/pkgconfig"
+    
+    echo -e "${GREEN}✓ Build configuration created${NC}"
+}
+
+# Function to patch source files for ARM64
+patch_source_files() {
+    echo -e "\n${BLUE}Patching source files for ARM64...${NC}"
+    
+    # Patch Makefile to remove -march=native
+    if [ -f "src/Makefile" ]; then
+        sed -i.bak 's/-march=native//g' src/Makefile
+    fi
+    
+    # Patch oomph-lib Makefile
+    if [ -f "src/thirdparty/oomph-lib/Makefile" ]; then
+        sed -i.bak 's/-march=native//g' src/thirdparty/oomph-lib/Makefile
+    fi
+    
+    # Create a patch for ccompiler.py to use OpenBLAS
+    cat > ccompiler_arm64_patch.py << 'EOF'
+# This patch modifies ccompiler.py to use OpenBLAS on ARM64
+import fileinput
+import sys
+
+for line in fileinput.input('pyoomph/generic/ccompiler.py', inplace=True):
+    if 'mkl' in line.lower() and 'import' not in line:
+        line = line.replace('mkl', 'openblas')
+    print(line, end='')
+EOF
+    
+    python ccompiler_arm64_patch.py
+    rm ccompiler_arm64_patch.py
+    
+    echo -e "${GREEN}✓ Source files patched${NC}"
+}
+
+# Function to install Python dependencies
+install_python_deps() {
+    echo -e "\n${BLUE}Installing Python dependencies (ARM64-compatible)...${NC}"
+    
+    # Set environment for scipy build
+    export OPENBLAS="/opt/homebrew/opt/openblas"
+    export LAPACK="/opt/homebrew/opt/lapack"
+    export BLAS=$OPENBLAS
+    
+    # Install build tools first
+    pip install --upgrade setuptools wheel cython meson-python
+    
+    # Install numpy (binary is fine for ARM64 now)
+    pip install numpy
+    
+    # Install scipy with proper OpenBLAS configuration
+    echo -e "${BLUE}Installing scipy with OpenBLAS...${NC}"
+    
+    # Create site.cfg for numpy/scipy
+    cat > site.cfg << EOF
+[DEFAULT]
+library_dirs = /opt/homebrew/lib
+include_dirs = /opt/homebrew/include
+
+[openblas]
+libraries = openblas
+library_dirs = /opt/homebrew/opt/openblas/lib
+include_dirs = /opt/homebrew/opt/openblas/include
+runtime_library_dirs = /opt/homebrew/opt/openblas/lib
+EOF
+    
+    # Try to install scipy
+    NPY_BLAS_ORDER=openblas NPY_LAPACK_ORDER=openblas pip install scipy || {
+        echo -e "${YELLOW}Standard scipy install failed, trying Apple Accelerate framework...${NC}"
+        
+        # Try with Apple's Accelerate framework
+        export ACCELERATE_LAPACK=1
+        export NPY_BLAS_ORDER=accelerate
+        export NPY_LAPACK_ORDER=accelerate
+        
+        pip install scipy --no-build-isolation --no-binary :all: || {
+            echo -e "${YELLOW}Source build failed, trying pre-built wheel...${NC}"
+            pip install scipy || {
+                echo -e "${YELLOW}Standard wheel failed, trying conda-forge scipy wheel...${NC}"
+                pip install scipy --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple || {
+                    echo -e "${RED}Failed to install scipy. All methods exhausted.${NC}"
+                    echo -e "${YELLOW}You may need to install scipy manually or use conda.${NC}"
+                }
+            }
+        }
+        
+        # Reset to OpenBLAS for other packages
+        export NPY_BLAS_ORDER=openblas
+        export NPY_LAPACK_ORDER=openblas
+    }
+    
+    # Install other dependencies
+    pip install matplotlib pybind11 gmsh commonmark six pyparsing pygments \
+                pillow mpi4py kiwisolver fonttools cycler rich \
+                python-dateutil packaging meshio pygmsh pybind11-stubgen
+    
+    # Clean up
+    rm -f site.cfg
+    
+    echo -e "${GREEN}✓ Python dependencies installed${NC}"
+}
+
+# Function to build oomph-lib
+build_oomph_lib() {
+    echo -e "\n${BLUE}Building oomph-lib for ARM64...${NC}"
+    
+    # Use the configuration file
+    export PYOOMPH_CONFIG_FILE=pyoomph_config_arm64.env
+    
+    # Run prebuild
+    bash ./prebuild.sh || {
+        echo -e "${YELLOW}Warning: prebuild.sh encountered issues, attempting to continue...${NC}"
+    }
+    
+    echo -e "${GREEN}✓ oomph-lib build completed${NC}"
+}
+
+# Function to build pyoomph
+build_pyoomph() {
+    echo -e "\n${BLUE}Building pyoomph for ARM64...${NC}"
+    
+    # Use the modified setup.py
+    python setup_arm64.py build_ext --inplace || {
+        echo -e "${RED}Build failed. Trying alternative approach...${NC}"
+        
+        # Alternative: use standard setup with environment variables
+        PYOOMPH_NO_MKL=1 PYOOMPH_USE_OPENBLAS=1 python setup.py build_ext --inplace
+    }
+    
+    # Install in development mode
+    pip install -e .
+    
+    echo -e "${GREEN}✓ pyoomph build completed${NC}"
+}
+
+# Function to verify installation
+verify_installation() {
+    echo -e "\n${BLUE}Verifying installation...${NC}"
+    
+    # Try to import pyoomph
+    python -c "import pyoomph; print('pyoomph version:', pyoomph.__version__)" || {
+        echo -e "${RED}Failed to import pyoomph${NC}"
+        return 1
+    }
+    
+    # Run basic checks
+    python -m pyoomph check compiler || {
+        echo -e "${YELLOW}Compiler check failed${NC}"
+    }
+    
+    echo -e "${GREEN}✓ Installation verified${NC}"
+}
+
+# Function to create test script
+create_test_script() {
+    echo -e "\n${BLUE}Creating test script...${NC}"
+    
+    cat > test_arm64_install.py << 'EOF'
+#!/usr/bin/env python3
+"""Test script for ARM64 pyoomph installation"""
+
+import sys
+print("Testing pyoomph ARM64 installation...")
+
+try:
+    import pyoomph
+    print(f"✓ pyoomph imported successfully (version: {pyoomph.__version__})")
+except ImportError as e:
+    print(f"✗ Failed to import pyoomph: {e}")
+    sys.exit(1)
+
+# Test basic functionality
+try:
+    from pyoomph import *
+    from pyoomph.expressions import *
+    print("✓ Basic imports successful")
+except Exception as e:
+    print(f"✗ Import error: {e}")
+
+# Test problem creation
+try:
+    class TestProblem(Problem):
+        def define_problem(self):
+            self.add_mesh(LineMesh(minimum=0, maximum=1, size=0.1))
+    
+    with TestProblem() as problem:
+        problem.solve()
+    print("✓ Simple problem solved")
+except Exception as e:
+    print(f"✗ Problem solving error: {e}")
+
+print("\nARM64 installation test completed!")
+EOF
+    
+    chmod +x test_arm64_install.py
+    echo -e "${GREEN}✓ Test script created${NC}"
+}
+
+
+# Function to restore original files
+restore_original_files() {
+    echo -e "\n${BLUE}Restoring original files and cleaning up...${NC}"
+    
+    # Restore pyproject.toml
+    if [ -f "pyproject.toml.original" ]; then
+        mv pyproject.toml.original pyproject.toml
+        echo -e "${GREEN}✓ Restored original pyproject.toml${NC}"
+    fi
+    
+    # Restore Makefiles from .bak files
+    if [ -f "src/Makefile.bak" ]; then
+        mv src/Makefile.bak src/Makefile
+        echo -e "${GREEN}✓ Restored original src/Makefile${NC}"
+    fi
+    
+    if [ -f "src/thirdparty/oomph-lib/Makefile.bak" ]; then
+        mv src/thirdparty/oomph-lib/Makefile.bak src/thirdparty/oomph-lib/Makefile
+        echo -e "${GREEN}✓ Restored original oomph-lib/Makefile${NC}"
+    fi
+    
+    # Clean up ARM64-specific files
+    rm -f setup_arm64.py
+    rm -f pyoomph_config_arm64.env
+    
+    # Clean up any other backup files
+    rm -f pyproject.toml.backup
+    rm -f setup.py.original
+    rm -f *.bak
+    
+    # Clean up temporary patch files
+    rm -f ccompiler_arm64_patch.py
+    rm -f site.cfg
+    
+    echo -e "${GREEN}✓ All cleanup completed${NC}"
+}
+
+# Main installation flow
+main() {
+    echo -e "${BLUE}Starting ARM64 native installation of pyoomph${NC}"
+    echo -e "${YELLOW}This process will modify source files for ARM64 compatibility${NC}"
+    echo ""
+    
+    # Check if we're in the pyoomph directory
+    if [ ! -f "setup.py" ] || [ ! -d "pyoomph" ]; then
+        echo -e "${RED}Error: This script must be run from the pyoomph root directory${NC}"
+        exit 1
+    fi
+    
+    # Set up trap to restore files on exit
+    trap 'restore_original_files' EXIT
+    
+    # Run installation steps
+    check_architecture
+    check_dependencies
+    install_system_deps
+    setup_python_env
+    modify_setup_py
+    create_build_config
+    patch_source_files
+    install_python_deps
+    build_oomph_lib
+    build_pyoomph
+    verify_installation
+    create_test_script
+    
+    echo -e "\n${GREEN}=== Installation Complete ===${NC}"
+    echo -e "${BLUE}To use pyoomph:${NC}"
+    echo "  1. Activate the environment: source py-oomph/bin/activate"
+    echo "  2. Test the installation: python test_arm64_install.py"
+    echo "  3. Run full tests: python -m pyoomph check all"
+    echo ""
+    echo -e "${YELLOW}Note: This is an experimental ARM64 build.${NC}"
+    echo -e "${YELLOW}Some features may not work as expected.${NC}"
+    echo -e "${YELLOW}Report any issues with ARM64 compatibility.${NC}"
+    
+    # Auto-activate the environment if not already active
+    if [[ "$VIRTUAL_ENV" != *"py-oomph"* ]]; then
+        echo -e "\n${BLUE}Activating py-oomph environment...${NC}"
+        source py-oomph/bin/activate
+        echo -e "${GREEN}✓ Environment activated. You are now in the py-oomph virtual environment.${NC}"
+        echo -e "${YELLOW}To deactivate later, run: deactivate${NC}"
+    else
+        echo -e "\n${GREEN}✓ py-oomph environment already active${NC}"
+    fi
+    
+    # Files will be restored automatically due to trap
+}
+
+# Run main function
+main

--- a/tests/test_installationArm.py
+++ b/tests/test_installationArm.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Test script for ARM64 pyoomph installation
+Tests basic functionality to ensure the installation is working correctly
+"""
+
+import sys
+import traceback
+
+# Import pyoomph at module level
+try:
+    from pyoomph import *
+    from pyoomph.expressions import *
+    from pyoomph.expressions.units import meter, second, kilogram
+    from pyoomph.equations.poisson import PoissonEquation
+    IMPORTS_OK = True
+except Exception as e:
+    IMPORTS_OK = False
+    IMPORT_ERROR = str(e)
+
+# Color codes for output
+GREEN = '\033[92m'
+RED = '\033[91m'
+YELLOW = '\033[93m'
+BLUE = '\033[94m'
+RESET = '\033[0m'
+
+def print_test(test_name, passed, message=""):
+    """Print test result with color"""
+    if passed:
+        print(f"{GREEN}✓ {test_name}{RESET}")
+    else:
+        print(f"{RED}✗ {test_name}{RESET}")
+        if message:
+            print(f"  {YELLOW}{message}{RESET}")
+
+def test_imports():
+    """Test basic imports"""
+    print(f"\n{BLUE}Testing imports...{RESET}")
+    
+    if not IMPORTS_OK:
+        print_test("Import pyoomph modules", False, IMPORT_ERROR)
+        return False
+    
+    print_test("Import pyoomph", True)
+    print_test("Import pyoomph.expressions", True)
+    print_test("Import specific equation module", True)
+    
+    return True
+
+def test_simple_poisson():
+    """Test solving a simple 1D Poisson problem"""
+    print(f"\n{BLUE}Testing 1D Poisson equation...{RESET}")
+    
+    if not IMPORTS_OK:
+        print_test("1D Poisson problem", False, "Imports failed")
+        return False
+    
+    try:
+        
+        class SimplePoissonProblem(Problem):
+            def define_problem(self):
+                # Simple 1D mesh
+                mesh = LineMesh(minimum=0, size=1, N=10)
+                self.add_mesh(mesh)
+                
+                # Add Poisson equation: -∇²u = 1
+                eqs = PoissonEquation(source=1)
+                eqs += DirichletBC(u=0)  # u=0 at boundaries
+                self.add_equations(eqs @ "domain")
+        
+        # Solve the problem
+        with SimplePoissonProblem() as problem:
+            problem.solve()
+            problem.output()
+        
+        print_test("1D Poisson problem", True)
+        return True
+        
+    except Exception as e:
+        print_test("1D Poisson problem", False, f"{type(e).__name__}: {str(e)}")
+        traceback.print_exc()
+        return False
+
+def test_2d_problem():
+    """Test a simple 2D problem"""
+    print(f"\n{BLUE}Testing 2D problem...{RESET}")
+    
+    if not IMPORTS_OK:
+        print_test("2D rectangular mesh problem", False, "Imports failed")
+        return False
+    
+    try:
+        
+        class Simple2DProblem(Problem):
+            def define_problem(self):
+                # Simple rectangular mesh
+                mesh = RectangularQuadMesh(size=[1, 1], N=[5, 5])
+                self.add_mesh(mesh)
+                
+                # Add Poisson equation
+                eqs = PoissonEquation()
+                eqs += DirichletBC(u=0) @ "left"
+                eqs += DirichletBC(u=0) @ "right"
+                eqs += DirichletBC(u=0) @ "top"
+                eqs += DirichletBC(u=0) @ "bottom"
+                self.add_equations(eqs @ "domain")
+        
+        with Simple2DProblem() as problem:
+            problem.solve()
+        
+        print_test("2D rectangular mesh problem", True)
+        return True
+        
+    except Exception as e:
+        print_test("2D rectangular mesh problem", False, f"{type(e).__name__}: {str(e)}")
+        return False
+
+def test_custom_equation():
+    """Test defining a custom equation"""
+    print(f"\n{BLUE}Testing custom equation definition...{RESET}")
+    
+    if not IMPORTS_OK:
+        print_test("Custom equation definition", False, "Imports failed")
+        return False
+    
+    try:
+        
+        class MyCustomEquation(Equations):
+            def define_fields(self):
+                self.define_scalar_field("u", "C2")
+            
+            def define_residuals(self):
+                u, u_test = var_and_test("u")
+                residual = weak(grad(u), grad(u_test)) + weak(u, u_test)
+                self.add_residual(residual)
+        
+        class CustomProblem(Problem):
+            def define_problem(self):
+                mesh = LineMesh(size=1, N=5)
+                self.add_mesh(mesh)
+                
+                eqs = MyCustomEquation()
+                eqs += DirichletBC(u=0)
+                self.add_equations(eqs @ "domain")
+        
+        with CustomProblem() as problem:
+            problem.solve()
+        
+        print_test("Custom equation definition", True)
+        return True
+        
+    except Exception as e:
+        print_test("Custom equation definition", False, f"{type(e).__name__}: {str(e)}")
+        return False
+
+def test_units():
+    """Test units system"""
+    print(f"\n{BLUE}Testing units system...{RESET}")
+    
+    if not IMPORTS_OK:
+        print_test("Units system", False, "Imports failed")
+        return False
+    
+    try:
+        
+        # Test basic unit operations
+        length = 2 * meter
+        time = 3 * second
+        velocity = length / time
+        
+        print_test("Units system", True)
+        return True
+        
+    except Exception as e:
+        print_test("Units system", False, f"{type(e).__name__}: {str(e)}")
+        return False
+
+def test_compiler():
+    """Test C compiler availability"""
+    print(f"\n{BLUE}Testing C compiler...{RESET}")
+    
+    try:
+        from pyoomph.generic.ccompiler import get_ccompiler
+        cc = get_ccompiler()
+        print_test(f"C compiler ({type(cc).__name__})", True)
+        return True
+        
+    except Exception as e:
+        print_test("C compiler", False, f"{type(e).__name__}: {str(e)}")
+        return False
+
+def test_solver_availability():
+    """Test available solvers"""
+    print(f"\n{BLUE}Testing solver availability...{RESET}")
+    
+    try:
+        from pyoomph.generic import Problem
+        from pyoomph.solvers.generic import GenericLinearSystemSolver, GenericEigenSolver
+        
+        p = Problem()
+        
+        # Test linear solvers
+        linear_solvers = ['superlu', 'umfpack', 'pardiso']
+        for solver in linear_solvers:
+            try:
+                GenericLinearSystemSolver.factory_solver(solver, p)
+                print_test(f"Linear solver: {solver}", True)
+            except:
+                print_test(f"Linear solver: {solver}", False, "Not available")
+        
+        # Test eigen solvers
+        eigen_solvers = ['scipy', 'pardiso']
+        for solver in eigen_solvers:
+            try:
+                GenericEigenSolver.factory_solver(solver, p)
+                print_test(f"Eigen solver: {solver}", True)
+            except:
+                print_test(f"Eigen solver: {solver}", False, "Not available")
+        
+        return True
+        
+    except Exception as e:
+        print_test("Solver availability check", False, f"{type(e).__name__}: {str(e)}")
+        return False
+
+def main():
+    """Run all tests"""
+    print(f"{BLUE}{'='*60}{RESET}")
+    print(f"{BLUE}pyoomph ARM64 Installation Test{RESET}")
+    print(f"{BLUE}{'='*60}{RESET}")
+    
+    # Track test results
+    results = []
+    
+    # Run tests
+    results.append(("Imports", test_imports()))
+    results.append(("Simple Poisson", test_simple_poisson()))
+    results.append(("2D Problem", test_2d_problem()))
+    results.append(("Custom Equation", test_custom_equation()))
+    results.append(("Units System", test_units()))
+    results.append(("C Compiler", test_compiler()))
+    results.append(("Solver Availability", test_solver_availability()))
+    
+    # Summary
+    print(f"\n{BLUE}{'='*60}{RESET}")
+    print(f"{BLUE}Test Summary:{RESET}")
+    print(f"{BLUE}{'='*60}{RESET}")
+    
+    passed = sum(1 for _, result in results if result)
+    total = len(results)
+    
+    for test_name, result in results:
+        status = f"{GREEN}PASSED{RESET}" if result else f"{RED}FAILED{RESET}"
+        print(f"{test_name:.<40} {status}")
+    
+    print(f"\n{BLUE}Total: {passed}/{total} tests passed{RESET}")
+    
+    if passed == total:
+        print(f"\n{GREEN}✓ All tests passed! pyoomph is working correctly on ARM64.{RESET}")
+        return 0
+    else:
+        print(f"\n{YELLOW}⚠ Some tests failed. Check the output above for details.{RESET}")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This pull request introduces an install and a test script for verifying the functionality of the `pyoomph` library on ARM64 systems. 

Works with M1 max macbook pro!

With the `installOnArm.sh` script, there won't be a need to use Rosetta2 terminal.. 

Downside: 
![CleanShot 2025-06-08 at 23 57 12@2x](https://github.com/user-attachments/assets/9006999d-4cdb-426c-bf82-0e4e55724656)


The mkl library (intel Sparse Matrix Solvers -- pardiso) is no longer available on apple's MXXX (and in general ARM) architecture. One can use scipy, umfpack, and umfpack ...

perhaps, another open source Sparse Matrix Solvers  is the way to go!!