### PR TITLE
Point the tutorial download buttons at the bundle, and stub preCICE for the docs

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -8,12 +8,13 @@
 
 .downloadbutton {
   margin: auto;
-  margin-bottom: 20px;  
-  width: 50%;
+  margin-bottom: 20px;
+  width: fit-content;
+  max-width: 100%;
   border: 2px solid rgb(165, 149, 224);
   background-color: rgb(225, 221, 235);
   text-align: center;
-  padding: 5px;  
+  padding: 5px 20px;
   border-radius: 7px;
 
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,6 +111,34 @@ autodoc_inherit_docstrings=False
 # name pyoomph.equations.navier_stokes pulls in from pyoomph.expressions. Keep the previous behaviour.
 autodoc_default_options = {"ignore-module-all": True}
 
+# preCICE is a heavy installation and is deliberately not a documentation requirement, so
+# pyoomph/solvers/precice_adapter.py's top-level "import precice" fails when the docs are built
+# (on Read the Docs, for instance) and its API page comes out empty. Stand a stub module in for it.
+#
+# autodoc_mock_imports=["precice"] is the idiomatic way to do this, but it is not enough here:
+# pyoomph/generic/problem.py annotates _precice_interface as "precice.Participant | None", and
+# sphinx_autodoc_typehints (which resolves "if TYPE_CHECKING:" blocks by executing them) cannot
+# evaluate that against autodoc's _MockObject. It then gives up on the whole module, and every
+# annotated Problem attribute silently loses its type cross-references. The stub therefore hands
+# out real classes, so "precice.Participant | None" evaluates like it does with preCICE installed.
+#
+# Only stand in when preCICE is genuinely unavailable, so a machine that has it documents the real
+# thing. "spec.origin is None" catches the namespace package that source/tutorial/precice would
+# otherwise become once build_tutorial_zip() below puts source/tutorial on sys.path: importing it
+# succeeds but yields an empty module, which is exactly what broke the annotations.
+import importlib.util as _importlib_util
+_precice_spec = _importlib_util.find_spec("precice")
+if _precice_spec is None or _precice_spec.origin is None:
+    import types as _types
+    _precice_stub = _types.ModuleType("precice")
+    _precice_stub_classes = {}
+    def _precice_stub_getattr(name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return _precice_stub_classes.setdefault(name, type(name, (), {"__module__": "precice"}))
+    _precice_stub.__getattr__ = _precice_stub_getattr
+    sys.modules["precice"] = _precice_stub
+
 # sphinx_autodoc_typehints resolves "if TYPE_CHECKING:" blocks by actually executing them, to
 # make forward-referenced types resolvable. pyoomph/meshes/mesh.py deliberately has TYPE_CHECKING-
 # only classes (_MeshFromTemplate1dTypingBase, _InterfaceMeshTypingBase, ...) that combine a

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -3,7 +3,7 @@ Pyoomph Tutorial
 ================
 
 :Author: Christian Diddens, Duarte Rocha & Maxim de Wildt
-:Date: 2026-07-16
+:Date: 2026-09-01
 
 
 .. toctree::

--- a/docs/source/tutorial/advstab/azimuthal/rbconvect.rst
+++ b/docs/source/tutorial/advstab/azimuthal/rbconvect.rst
@@ -82,6 +82,8 @@ Finally, we trace out the critical curve :math:`\operatorname{Ra}_\text{c}(\Gamm
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <rayleigh_benard_azimuthal_stability.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Advanced_Linear_Dynamics/rayleigh_benard_azimuthal_stability.py``

--- a/docs/source/tutorial/advstab/azimuthal/rising_bubble.rst
+++ b/docs/source/tutorial/advstab/azimuthal/rising_bubble.rst
@@ -82,7 +82,9 @@ We can also generate a movie of the instability. Please refer to :numref:`secplo
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <rising_bubble.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Advanced_Linear_Dynamics/rising_bubble.py``
 

--- a/docs/source/tutorial/advstab/bifgui/example.rst
+++ b/docs/source/tutorial/advstab/bifgui/example.rst
@@ -101,7 +101,9 @@ The orbit handler is installed afterwards, i.e. the problem solves for the entir
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <thin_film_bifurcation_gui.py>`
+		Full code available in the
 
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Advanced_Linear_Dynamics/thin_film_bifurcation_gui.py``
 	

--- a/docs/source/tutorial/advstab/cartesiannormal/rivulet.rst
+++ b/docs/source/tutorial/advstab/cartesiannormal/rivulet.rst
@@ -72,6 +72,8 @@ Here :py:class:`~pyoomph.meshes.meshdatacache.MeshDataCombineWithEigenfunction` 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <rivulet.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Advanced_Linear_Dynamics/rivulet.py``

--- a/docs/source/tutorial/advstab/cartesiannormal/turingdispersion.rst
+++ b/docs/source/tutorial/advstab/cartesiannormal/turingdispersion.rst
@@ -53,6 +53,8 @@ In particular, we can quickly get a good guess for the dominant wavenumber, here
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <turing_dispersion.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Advanced_Linear_Dynamics/turing_dispersion.py``

--- a/docs/source/tutorial/advstab/eigenconti.rst
+++ b/docs/source/tutorial/advstab/eigenconti.rst
@@ -40,9 +40,11 @@ Once set up, we can use this problem and solve for the stationary state at the m
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <eigenbranch_continuation.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Advanced_Linear_Dynamics/eigenbranch_continuation.py``
 		    
 
 

--- a/docs/source/tutorial/advstab/movmesh/dropdetach.rst
+++ b/docs/source/tutorial/advstab/movmesh/dropdetach.rst
@@ -76,6 +76,8 @@ Of course, the choice to nondimensionalize the system by the contact line radius
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <hanging_droplet.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Advanced_Linear_Dynamics/hanging_droplet.py``

--- a/docs/source/tutorial/advstab/response/dampedho.rst
+++ b/docs/source/tutorial/advstab/response/dampedho.rst
@@ -55,7 +55,9 @@ Before the problem is initialized, we must create a :py:class:`~pyoomph.utils.pe
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <linear_response_oscillator.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Advanced_Linear_Dynamics/linear_response_oscillator.py``
  

--- a/docs/source/tutorial/advstab/response/drums.rst
+++ b/docs/source/tutorial/advstab/response/drums.rst
@@ -46,6 +46,8 @@ To obtain the full response data, we can access the eigenvector of the problem. 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <linear_response_drum.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Advanced_Linear_Dynamics/linear_response_drum.py``

--- a/docs/source/tutorial/ale/aledt.rst
+++ b/docs/source/tutorial/ale/aledt.rst
@@ -80,7 +80,9 @@ The field :math:`c` is now not following the oscillatory motion of the mesh, but
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <ALE_correction.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/ALE_correction.py``
 		    

--- a/docs/source/tutorial/ale/beadsonstring.rst
+++ b/docs/source/tutorial/ale/beadsonstring.rst
@@ -92,6 +92,8 @@ The finer mesh is not optional -- the reference notes the same requirement -- an
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <beads_on_string.py>`
+		Full code available in the
 
-		:download:`Download all examples <../tutorial_example_scripts.zip>`
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/beads_on_string.py``

--- a/docs/source/tutorial/ale/freesurf.rst
+++ b/docs/source/tutorial/ale/freesurf.rst
@@ -126,7 +126,9 @@ As opposed to the lubrication example in :numref:`eqpdelubric_relax`, we use a :
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <free_surface.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/free_surface.py``
 		    

--- a/docs/source/tutorial/ale/gmshfields.rst
+++ b/docs/source/tutorial/ale/gmshfields.rst
@@ -90,7 +90,9 @@ The results in figure :numref:`figrayleighplateauinstab` show how the remeshing 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <rayleigh_plateau.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/rayleigh_plateau.py``
 		    

--- a/docs/source/tutorial/ale/laplsmooth.rst
+++ b/docs/source/tutorial/ale/laplsmooth.rst
@@ -46,7 +46,9 @@ Finally, the :py:class:`~pyoomph.equations.generic.SpatialErrorEstimator` will r
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <laplace_smoothed_mesh.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/laplace_smoothed_mesh.py``
 		    

--- a/docs/source/tutorial/ale/pinchoff.rst
+++ b/docs/source/tutorial/ale/pinchoff.rst
@@ -117,6 +117,8 @@ i.e. the break-up costs about what remeshing the same mesh costs anyway, and bot
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <rayleigh_plateau_pinchoff.py>`
+		Full code available in the
 
-		:download:`Download all examples <../tutorial_example_scripts.zip>`
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/rayleigh_plateau_pinchoff.py``

--- a/docs/source/tutorial/ale/remesh.rst
+++ b/docs/source/tutorial/ale/remesh.rst
@@ -58,7 +58,9 @@ One additional option is to add an instance of the class :py:class:`~pyoomph.equ
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <remeshing.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/remeshing.py``
 		    

--- a/docs/source/tutorial/ale/solid/cantilever.rst
+++ b/docs/source/tutorial/ale/solid/cantilever.rst
@@ -49,7 +49,9 @@ Finally, we can just run the problem by gradually increasing the pressure load, 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <cantilever.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/cantilever.py``
 		    		

--- a/docs/source/tutorial/ale/solid/compressed_disc.rst
+++ b/docs/source/tutorial/ale/solid/compressed_disc.rst
@@ -45,7 +45,9 @@ In the driver code, we just iterate over the imposed pressure (starting with a n
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <compressed_disc.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/compressed_disc.py``
 		    		

--- a/docs/source/tutorial/ale/solid/solid_oscillations.rst
+++ b/docs/source/tutorial/ale/solid/solid_oscillations.rst
@@ -30,7 +30,9 @@ For the torsion, we use the original undeformed beam by accessing the Lagrangian
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <solid_oscillations.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/solid_oscillations.py``
 		    		

--- a/docs/source/tutorial/ale/spread/free.rst
+++ b/docs/source/tutorial/ale/spread/free.rst
@@ -39,7 +39,9 @@ Important differences are the mesh, which is now the north-east (``"NE"``) quart
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <droplet_spread_free_slip.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/droplet_spread_free_slip.py``
 		    

--- a/docs/source/tutorial/ale/spread/hyperelastic.rst
+++ b/docs/source/tutorial/ale/spread/hyperelastic.rst
@@ -42,8 +42,10 @@ The issue without shifting the tangent node positions is shown in the left part 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <droplet_spread_hyperelastic_tangential_shift.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/droplet_spread_hyperelastic_tangential_shift.py``
 
 

--- a/docs/source/tutorial/ale/spread/maraandgrav.rst
+++ b/docs/source/tutorial/ale/spread/maraandgrav.rst
@@ -84,9 +84,11 @@ The method :py:meth:`~pyoomph.generic.problem.Problem.go_to_param` will graduall
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <droplet_spread_marangoni_and_gravity.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/droplet_spread_marangoni_and_gravity.py``
 		    
 
 

--- a/docs/source/tutorial/ale/spread/navier.rst
+++ b/docs/source/tutorial/ale/spread/navier.rst
@@ -37,7 +37,9 @@ A comparison of results without and with slip length can be seen on the right si
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <droplet_spread_sliplength.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/droplet_spread_sliplength.py``
 		    

--- a/docs/source/tutorial/ale/spread/threedim.rst
+++ b/docs/source/tutorial/ale/spread/threedim.rst
@@ -43,7 +43,9 @@ Since we are mostly interested in the final state of the droplet, we have not co
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <droplet_spread_3d.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Moving_Mesh/droplet_spread_3d.py``
 		    

--- a/docs/source/tutorial/dg/advdiffu.rst
+++ b/docs/source/tutorial/dg/advdiffu.rst
@@ -141,9 +141,11 @@ The discontinuous output is plotted in :numref:`figdgconvdiffu`.
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <convection_diffusion.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Discontinuous_Galerkin/convection_diffusion.py``
 		   
 
 .. note::

--- a/docs/source/tutorial/dg/facetfields.rst
+++ b/docs/source/tutorial/dg/facetfields.rst
@@ -146,6 +146,8 @@ An unknown on the facets also changes what the *bulk* unknowns are coupled to. W
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <hybrid_poisson.py>`
+		Full code available in the
 
-		:download:`Download all examples <../tutorial_example_scripts.zip>`
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Discontinuous_Galerkin/hybrid_poisson.py``

--- a/docs/source/tutorial/dg/hdg.rst
+++ b/docs/source/tutorial/dg/hdg.rst
@@ -106,6 +106,8 @@ The elimination is exact, so the accuracy is that of the unreduced scheme. Refin
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <hdg_poisson.py>`
+		Full code available in the
 
-		:download:`Download all examples <../tutorial_example_scripts.zip>`
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Discontinuous_Galerkin/hdg_poisson.py``

--- a/docs/source/tutorial/dg/weakdirichlet.rst
+++ b/docs/source/tutorial/dg/weakdirichlet.rst
@@ -42,9 +42,11 @@ By default, :py:class:`~pyoomph.equations.generic.DirichletBC` will impose the c
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <poisson_weak_dirichlet.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Discontinuous_Galerkin/poisson_weak_dirichlet.py``
  
 
 Finally, we want to address that the discontinuous Galerkin implementation can easily be switched to a *finite volume method*. In such methods, quantities are usually element-wise constant, i.e. approximated on the space ``"D0"``. If setting ``space="D0"``, all terms involving ``grad(u)`` and ``grad(v)`` will vanish, since the gradients are zero in the element-wise constant space. The weak formulation will hence only read 

--- a/docs/source/tutorial/mcflow/gcl.rst
+++ b/docs/source/tutorial/mcflow/gcl.rst
@@ -106,7 +106,9 @@ The conservative form can be combined with stability analysis, i.e. with solving
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <gcl_glycerol_water_capillary.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Multicomponent_Flow/gcl_glycerol_water_capillary.py``
 		   

--- a/docs/source/tutorial/mcflow/marainstab.rst
+++ b/docs/source/tutorial/mcflow/marainstab.rst
@@ -74,7 +74,9 @@ The results are depicted in :numref:`figmcflowheleshaw` and indeed show the expe
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <marangoni_instability.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Multicomponent_Flow/marangoni_instability.py``
 		   

--- a/docs/source/tutorial/mcflow/matlib/gas.rst
+++ b/docs/source/tutorial/mcflow/matlib/gas.rst
@@ -32,7 +32,9 @@ You can hence create an instance of the pure gas ``"air"`` by calling :py:func:`
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <materials_pure_gas.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Multicomponent_Flow/materials_pure_gas.py``
 		   

--- a/docs/source/tutorial/mcflow/matlib/gasmix.rst
+++ b/docs/source/tutorial/mcflow/matlib/gasmix.rst
@@ -65,7 +65,9 @@ Of course, also the thermal properties :py:attr:`~pyoomph.materials.generic.Mate
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <materials_gas_mixture.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Multicomponent_Flow/materials_gas_mixture.py``
 		   

--- a/docs/source/tutorial/mcflow/matlib/liquid.rst
+++ b/docs/source/tutorial/mcflow/matlib/liquid.rst
@@ -24,7 +24,9 @@ Loading a pure liquid from the material library works exactly as loading a pure 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <materials_liquids.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Multicomponent_Flow/materials_liquids.py``
 		   

--- a/docs/source/tutorial/mcflow/matlib/liquidmix.rst
+++ b/docs/source/tutorial/mcflow/matlib/liquidmix.rst
@@ -20,7 +20,9 @@ We can set the activity coefficients either directly by setting the ``dict`` val
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <materials_liquids.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Multicomponent_Flow/materials_liquids.py``
 		   

--- a/docs/source/tutorial/mcflow/matlib/ptdep.rst
+++ b/docs/source/tutorial/mcflow/matlib/ptdep.rst
@@ -46,7 +46,9 @@ Likewise, you can write this data to a file. Thereby, you can easily check wheth
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <temperature_and_pressure_dependency.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Multicomponent_Flow/temperature_and_pressure_dependency.py``
 		   

--- a/docs/source/tutorial/mcflow/rtinstab.rst
+++ b/docs/source/tutorial/mcflow/rtinstab.rst
@@ -55,7 +55,9 @@ The benefit of using the material library is that it is now trivial to exchange 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <rayleigh_taylor_instability.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Multicomponent_Flow/rayleigh_taylor_instability.py``
 		   

--- a/docs/source/tutorial/mcflow/salts/capillary.rst
+++ b/docs/source/tutorial/mcflow/salts/capillary.rst
@@ -77,6 +77,8 @@ Summarizing, at :math:`1\:\mathrm{mM}` of a typical buffer the two are indisting
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <nacl_capillary_evaporation.py>`
+		Full code available in the
 
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Multicomponent_Flow/nacl_capillary_evaporation.py``

--- a/docs/source/tutorial/mcflow/salts/double_layer.rst
+++ b/docs/source/tutorial/mcflow/salts/double_layer.rst
@@ -88,6 +88,8 @@ Across all runs the sum drifts by less than :math:`10^{-15}` relative, i.e. it i
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <double_layer_relaxation.py>`
+		Full code available in the
 
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Multicomponent_Flow/double_layer_relaxation.py``

--- a/docs/source/tutorial/mcflow/surfact/define.rst
+++ b/docs/source/tutorial/mcflow/surfact/define.rst
@@ -40,7 +40,9 @@ However, ``sigma1`` will still depend on the surface concentration :math:`\Gamma
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <insoluble_surfactant_definition.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Multicomponent_Flow/insoluble_surfactant_definition.py``
 		   

--- a/docs/source/tutorial/mcflow/surfact/soluble.rst
+++ b/docs/source/tutorial/mcflow/surfact/soluble.rst
@@ -84,7 +84,9 @@ Both differ by the mass fraction of the surfactant itself, i.e. not at all in th
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <soluble_surfactants.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Multicomponent_Flow/soluble_surfactants.py``
 		   

--- a/docs/source/tutorial/multidom/conduction.rst
+++ b/docs/source/tutorial/multidom/conduction.rst
@@ -65,9 +65,11 @@ The driver code is quite trivial
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <temperature_conduction.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Multiple_Domains/temperature_conduction.py``
 		    
 
 

--- a/docs/source/tutorial/multidom/evap.rst
+++ b/docs/source/tutorial/multidom/evap.rst
@@ -110,7 +110,9 @@ The run script is trivial and the results are shown in :numref:`figmultidomdrope
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <evaporating_water_droplet.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Multiple_Domains/evaporating_water_droplet.py``
 		      

--- a/docs/source/tutorial/multidom/icefront.rst
+++ b/docs/source/tutorial/multidom/icefront.rst
@@ -116,7 +116,9 @@ The results are shown in :numref:`figmultidomiceprop1d`.
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <temperature_conduction_propagation.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Multiple_Domains/temperature_conduction_propagation.py``
 		    

--- a/docs/source/tutorial/multidom/melting.rst
+++ b/docs/source/tutorial/multidom/melting.rst
@@ -100,7 +100,9 @@ The corresponding results are shown in :numref:`figmultidomicecylinder`. Obvious
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <melting_ice_convection.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Multiple_Domains/melting_ice_convection.py``
 		    

--- a/docs/source/tutorial/multidom/simple_fsi.rst
+++ b/docs/source/tutorial/multidom/simple_fsi.rst
@@ -43,7 +43,9 @@ Note that spatial adaptivity is driven here by a :py:class:`~pyoomph.equations.g
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <simple_fsi.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Multiple_Domains/simple_fsi.py``
 		    		

--- a/docs/source/tutorial/multidom/stokeslaw.rst
+++ b/docs/source/tutorial/multidom/stokeslaw.rst
@@ -28,9 +28,11 @@ In the :py:meth:`~pyoomph.generic.problem.Problem.define_problem` method, we rem
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <falling_droplet.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Multiple_Domains/falling_droplet.py``
 		   
 
 When we have static meshes (i.e. no equations for the mesh positions are added), we must add ``static_interface=True`` to the :py:class:`~pyoomph.equations.navier_stokes.NavierStokesFreeSurface`. With that, the action of the Lagrange multiplier of the kinematic boundary condition :math:numref:`eqalekinbcweak` will be added to the velocity, not the mesh motion. Since the latter is not allowed to move, only an adjustment of the velocity can guarantee the kinematic boundary condition to hold. Thereby, the kinematic boundary condition is effectively replaced by a zero normal flow condition, i.e. :math:numref:`eqspatialnofluxlagrange`.
@@ -80,7 +82,9 @@ The surfactants get advected to the top of the droplet and hamper the flow in th
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <falling_droplet_with_surfactants.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Multiple_Domains/falling_droplet_with_surfactants.py``
 		   

--- a/docs/source/tutorial/multidom/twofluids.rst
+++ b/docs/source/tutorial/multidom/twofluids.rst
@@ -115,9 +115,11 @@ and the results are depicted in :numref:`figmultidomtwolayer`.
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <two_layer_flow.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Multiple_Domains/two_layer_flow.py``
 		    
 
 .. tip::

--- a/docs/source/tutorial/pde/adapt/cylinder.rst
+++ b/docs/source/tutorial/pde/adapt/cylinder.rst
@@ -138,6 +138,8 @@ that out of the only purse available.
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <heated_cylinder.py>`
+		Full code available in the
 
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/heated_cylinder.py``

--- a/docs/source/tutorial/pde/adapt/moffatt.rst
+++ b/docs/source/tutorial/pde/adapt/moffatt.rst
@@ -214,6 +214,8 @@ whether your constraints are honoured.
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <moffatt_eddies.py>`
+		Full code available in the
 
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/moffatt_eddies.py``

--- a/docs/source/tutorial/pde/convdiffu/naive.rst
+++ b/docs/source/tutorial/pde/convdiffu/naive.rst
@@ -44,7 +44,9 @@ Results at different times are depicted in :numref:`figpdesimpleconvdiffu`.
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <convdiffu_simple.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/convdiffu_simple.py``
 		    

--- a/docs/source/tutorial/pde/convdiffu/supg.rst
+++ b/docs/source/tutorial/pde/convdiffu/supg.rst
@@ -83,7 +83,9 @@ Results are depicted in :numref:`figpdesupg`.
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <convdiffu_SUPG.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/convdiffu_SUPG.py``
 		    

--- a/docs/source/tutorial/pde/lubric/coalesce.rst
+++ b/docs/source/tutorial/pde/lubric/coalesce.rst
@@ -29,7 +29,9 @@ One can rather easily add e.g. (in)soluble surfactants or a mixture composition 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <lubrication_coalescence.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/lubrication_coalescence.py``
 		    

--- a/docs/source/tutorial/pde/lubric/relax.rst
+++ b/docs/source/tutorial/pde/lubric/relax.rst
@@ -26,7 +26,9 @@ The result is depicted in :numref:`figpdelubrication`.
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <lubrication.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/lubrication.py``
 		    

--- a/docs/source/tutorial/pde/lubric/spread.rst
+++ b/docs/source/tutorial/pde/lubric/spread.rst
@@ -24,7 +24,9 @@ We can use the same equation class to calculate the spreading of a droplet. For 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <lubrication_spreading.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/lubrication_spreading.py``
 		    

--- a/docs/source/tutorial/pde/navier/marainstab.rst
+++ b/docs/source/tutorial/pde/navier/marainstab.rst
@@ -35,7 +35,9 @@ The Marangoni instability is the explanation why e.g. evaporating droplets consi
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <marangoni_instability.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/marangoni_instability.py``
 		    

--- a/docs/source/tutorial/pde/navier/rtinstab.rst
+++ b/docs/source/tutorial/pde/navier/rtinstab.rst
@@ -26,7 +26,9 @@ If you have read the tutorial up to here, you should understand all steps. The i
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <rayleigh_taylor_instability.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/rayleigh_taylor_instability.py``
 		    

--- a/docs/source/tutorial/pde/navier/transientstokes.rst
+++ b/docs/source/tutorial/pde/navier/transientstokes.rst
@@ -67,7 +67,9 @@ As seen in :numref:`figpdetransientstokeslaw`, the final velocity field is not s
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <navier_stokes_around_object.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/navier_stokes_around_object.py``
 		    

--- a/docs/source/tutorial/pde/navier/viscoelastic.rst
+++ b/docs/source/tutorial/pde/navier/viscoelastic.rst
@@ -112,6 +112,8 @@ The agreement is within :math:`0.005\,\%` over the whole range for which the ref
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <viscoelastic_cylinder.py>`
+		Full code available in the
 
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/viscoelastic_cylinder.py``

--- a/docs/source/tutorial/pde/navier/womersley.rst
+++ b/docs/source/tutorial/pde/navier/womersley.rst
@@ -24,7 +24,9 @@ Due to the inertia, the flow reversal does not happen instantaneously, but shows
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <navier_stokes.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/navier_stokes.py``
 		    

--- a/docs/source/tutorial/pde/patterns/biftrack.rst
+++ b/docs/source/tutorial/pde/patterns/biftrack.rst
@@ -41,8 +41,10 @@ Similarly, we can set the other :py:class:`~pyoomph.equations.generic.InitialCon
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <kuramoto_sivanshinsky_bifurcation.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/kuramoto_sivanshinsky_bifurcation.py``
 		    
 

--- a/docs/source/tutorial/pde/patterns/eigen.rst
+++ b/docs/source/tutorial/pde/patterns/eigen.rst
@@ -97,8 +97,10 @@ The rms is used as the y-axis to show the amplitude of the patterns. Obviously, 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <kuramoto_sivanshinsky_arclength_eigen.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/kuramoto_sivanshinsky_arclength_eigen.py``
 		    
 

--- a/docs/source/tutorial/pde/patterns/kse.rst
+++ b/docs/source/tutorial/pde/patterns/kse.rst
@@ -71,8 +71,10 @@ The problem code is simple and representative results of the pattern formation a
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <kuramoto_sivanshinsky.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/kuramoto_sivanshinsky.py``
 		    
 

--- a/docs/source/tutorial/pde/wave/doubleslit.rst
+++ b/docs/source/tutorial/pde/wave/doubleslit.rst
@@ -54,7 +54,9 @@ In the results (cf. :numref:`figpdewavedoubleslit`) we indeed see that the incom
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <wave_eq_doubleslit.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/wave_eq_doubleslit.py``
 		    

--- a/docs/source/tutorial/pde/wave/drums.rst
+++ b/docs/source/tutorial/pde/wave/drums.rst
@@ -37,7 +37,9 @@ First of all, we use the :py:class:`~pyoomph.meshes.simplemeshes.CircularMesh`, 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <wave_eq_drums.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/wave_eq_drums.py``
 		    

--- a/docs/source/tutorial/pde/wave/onedim.rst
+++ b/docs/source/tutorial/pde/wave/onedim.rst
@@ -48,7 +48,9 @@ Without the ``DirichletBC(u=0)`` terms, the :math:`\langle \cdot, \cdot \rangle`
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <wave_eq.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``SpatioTemporal_PDEs/wave_eq.py``
 		    

--- a/docs/source/tutorial/plotting/droplet.rst
+++ b/docs/source/tutorial/plotting/droplet.rst
@@ -79,6 +79,8 @@ On each output, the plotter(s) will be invoked to create each a plot in the ``_p
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <plotting_evaporating_droplet.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Plotting_Interface/plotting_evaporating_droplet.py``

--- a/docs/source/tutorial/plotting/eigendynamics.rst
+++ b/docs/source/tutorial/plotting/eigendynamics.rst
@@ -40,8 +40,10 @@ The animation also works when the mesh is distributed over several processes wit
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <eigendynamics.py>`
+		Full code available in the
 
-		:download:`Download all examples <../tutorial_example_scripts.zip>`
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Plotting_Interface/eigendynamics.py``
 
 

--- a/docs/source/tutorial/plotting/eigenfuncs.rst
+++ b/docs/source/tutorial/plotting/eigenfuncs.rst
@@ -36,6 +36,8 @@ Some plots are depicted in :numref:`figplottingeigenkse`. As expected, the criti
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <plotting_eigenmodes.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Plotting_Interface/plotting_eigenmodes.py``

--- a/docs/source/tutorial/plotting/one_dimensional.rst
+++ b/docs/source/tutorial/plotting/one_dimensional.rst
@@ -92,6 +92,8 @@ be plotted against another field.
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <one_dimensional.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Plotting_Interface/one_dimensional.py``

--- a/docs/source/tutorial/plotting/tracers.rst
+++ b/docs/source/tutorial/plotting/tracers.rst
@@ -124,6 +124,8 @@ Some further remarks
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <tracers.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Plotting_Interface/tracers.py``

--- a/docs/source/tutorial/precice/coupled_heat.rst
+++ b/docs/source/tutorial/precice/coupled_heat.rst
@@ -65,7 +65,9 @@ If you run the scripts without setting :py:attr:`~pyoomph.generic.problem.Proble
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <partitioned_heat_conduction.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``PreCICE_Coupling/partitioned_heat_conduction.py``
 		    

--- a/docs/source/tutorial/precice/coupled_heat_circle.rst
+++ b/docs/source/tutorial/precice/coupled_heat_circle.rst
@@ -59,7 +59,9 @@ For running with preCICE, you must place the config file :download:`precice-conf
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <partitioned_heat_conduction_circle.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``PreCICE_Coupling/partitioned_heat_conduction_circle.py``
 		    

--- a/docs/source/tutorial/spatial/helmholtz.rst
+++ b/docs/source/tutorial/spatial/helmholtz.rst
@@ -164,6 +164,8 @@ The results are depicted in :numref:`fighelmholtzPML` and speak for themselves. 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <helmholtz_pml.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/helmholtz_pml.py``

--- a/docs/source/tutorial/spatial/mesh/byhand.rst
+++ b/docs/source/tutorial/spatial/mesh/byhand.rst
@@ -47,7 +47,9 @@ The predefined :py:class:`~pyoomph.equations.poisson.PoissonEquation` works as t
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <mesh_Lshape_by_hand.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/mesh_Lshape_by_hand.py``
 		    

--- a/docs/source/tutorial/spatial/mesh/curvedline.rst
+++ b/docs/source/tutorial/spatial/mesh/curvedline.rst
@@ -33,9 +33,11 @@ A potential driver code could read
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <mesh_helical_line.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/mesh_helical_line.py``
 		    
 
 

--- a/docs/source/tutorial/spatial/mesh/gmsh.rst
+++ b/docs/source/tutorial/spatial/mesh/gmsh.rst
@@ -46,9 +46,11 @@ The differences are that we do not allow for spatial adaptivity and introduce ne
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <mesh_gmsh_fish_mesh_modes.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/mesh_gmsh_fish_mesh_modes.py``
 		    
 
 .. warning::

--- a/docs/source/tutorial/spatial/mesh/resolution.rst
+++ b/docs/source/tutorial/spatial/mesh/resolution.rst
@@ -47,7 +47,9 @@ so that the result looks as depicted in :numref:`figspatialfishgmsheye`. Since o
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <mesh_gmsh_fish_with_holes.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/mesh_gmsh_fish_with_holes.py``
 		    

--- a/docs/source/tutorial/spatial/mesh/unitsandmacro.rst
+++ b/docs/source/tutorial/spatial/mesh/unitsandmacro.rst
@@ -87,8 +87,10 @@ Finally, if your parametric coordinate is periodic (an angle, say), implement ``
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <mesh_fish_dimensional_curved.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/mesh_fish_dimensional_curved.py``
 		    
 

--- a/docs/source/tutorial/spatial/poisson/adapt.rst
+++ b/docs/source/tutorial/spatial/poisson/adapt.rst
@@ -28,10 +28,12 @@ The result is depicted in :numref:`figspatialpoissonadapt`. Obviously, the adapt
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <poisson_2d_adaptive.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
-		    
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/poisson_2d_adaptive.py``
+
 
 .. tip::
 

--- a/docs/source/tutorial/spatial/poisson/coordsys.rst
+++ b/docs/source/tutorial/spatial/poisson/coordsys.rst
@@ -29,7 +29,9 @@ Besides the coordinate system ``axisymmetric``, which works in :math:`1`\ d and 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <poisson_axisymm_adaptive.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/poisson_axisymm_adaptive.py``
 		    

--- a/docs/source/tutorial/spatial/poisson/neumann.rst
+++ b/docs/source/tutorial/spatial/poisson/neumann.rst
@@ -27,9 +27,11 @@ In the :py:meth:`~pyoomph.generic.problem.Problem.define_problem` method of the 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <poisson_neumann.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/poisson_neumann.py``
 		    
 
 It is not necessary to implement a Neumann condition for each equation by hand as done with the ``PoissonNeumannCondition`` class. Instead, pyoomph offers the class :py:class:`~pyoomph.equations.generic.NeumannBC`, which allows us to add the weak contribution :math:`\langle j_\text{N},v \rangle` directly. However, one has to consider the sign: In the weak form of the Poisson equation :math:numref:`eqspatialpoissonweak`, the :math:`\langle \ldots \rangle` term has a negative sign, which is accounted for in the implementation of the ``PoissonNeumannCondition``. The generic class :py:class:`~pyoomph.equations.generic.NeumannBC` uses a positive sign instead. One hence has to use ``NeumannBC(u=1.5)`` to get the same effect as ``PoissonNeumannCondition("u",-1.5)``. Note that the keyword argument in ``NeumannBC(u=1.5)`` should be read as *impose the Neumann flux* :math:`1.5` *for* :math:`u`, **not** *set* :math:`u=1.5`, which would be Dirichlet-like.

--- a/docs/source/tutorial/spatial/poisson/onedimcoupled.rst
+++ b/docs/source/tutorial/spatial/poisson/onedimcoupled.rst
@@ -33,7 +33,9 @@ Also note how :py:class:`~pyoomph.equations.generic.DirichletBC` takes multiple 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <poisson_coupled.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/poisson_coupled.py``
 		    

--- a/docs/source/tutorial/spatial/poisson/onedimdbc.rst
+++ b/docs/source/tutorial/spatial/poisson/onedimdbc.rst
@@ -53,7 +53,9 @@ Opposed to the ODEs in the previous chapter, there is no need for a temporal int
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <poisson.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/poisson.py``
 		    

--- a/docs/source/tutorial/spatial/poisson/pureneumann.rst
+++ b/docs/source/tutorial/spatial/poisson/pureneumann.rst
@@ -86,7 +86,9 @@ Obviously, the previous constraint :math:numref:`eqspatialpoissonneumconstr` can
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <poisson_pure_neumann_nullspace.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/poisson_pure_neumann_nullspace.py``
 		    

--- a/docs/source/tutorial/spatial/poisson/robin.rst
+++ b/docs/source/tutorial/spatial/poisson/robin.rst
@@ -29,9 +29,11 @@ and just add this term in the same manner as the Neumann condition, i.e. via :ma
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <poisson_robin_via_neumann.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/poisson_robin_via_neumann.py``
 		    
 
 Of course, you can recover the Neumann condition as a special case by setting :math:`\alpha=0`, but you cannot recover the Dirichlet condition, since :math:`\beta=0` will induce a division by zero.
@@ -65,9 +67,11 @@ The outward unit normal is obtained by :py:meth:`~pyoomph.generic.codegen.BaseEq
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <poisson_robin_via_lagrange.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/poisson_robin_via_lagrange.py``
 		    
 
 For the latter approach, there is also a generic class :py:class:`~pyoomph.equations.generic.EnforcedBC`, which allows us to enforce arbitrary boundary conditions. To get the same result as with the custom implemented class ``PoissonRobinCondition("u",alpha,beta,g)``, the generic class requires to cast it into residual form, i.e. ``EnforcedBC(u=alpha*var("u")+beta*dot(grad(var("u",domain="..")),var("normal"))-g)``.

--- a/docs/source/tutorial/spatial/poisson/twodim.rst
+++ b/docs/source/tutorial/spatial/poisson/twodim.rst
@@ -53,7 +53,9 @@ If a boundary is selected by a pattern and also addressed explicitly, both are a
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <poisson_2d.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/poisson_2d.py``
 		    

--- a/docs/source/tutorial/spatial/stokes/cr_condensation.rst
+++ b/docs/source/tutorial/spatial/stokes/cr_condensation.rst
@@ -139,7 +139,9 @@ However, there is of course overhead associated with the condensation in the ass
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <cr_static_condensation.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/cr_static_condensation.py``
 		    

--- a/docs/source/tutorial/spatial/stokes/dimtraction.rst
+++ b/docs/source/tutorial/spatial/stokes/dimtraction.rst
@@ -75,7 +75,9 @@ The :py:class:`~pyoomph.output.meshio.MeshFileOutput` will write the result in d
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <stokes_dimensional.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/stokes_dimensional.py``
 		    

--- a/docs/source/tutorial/spatial/stokes/implement.rst
+++ b/docs/source/tutorial/spatial/stokes/implement.rst
@@ -48,7 +48,9 @@ It is trivial to try out other pairs of spaces, but it turns out that for the ch
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <stokes.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/stokes.py``
 		    

--- a/docs/source/tutorial/spatial/stokes/inverse_problem.rst
+++ b/docs/source/tutorial/spatial/stokes/inverse_problem.rst
@@ -55,9 +55,11 @@ This can all be achieved in a single :py:class:`~pyoomph.equations.generic.Integ
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <cavity_forward_problem.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/cavity_forward_problem.py``
 		
 		
 Inverse problem
@@ -126,9 +128,11 @@ At this point, one could of course do a scan in :math:`U_\text{desired}`, but th
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <cavity_inverse_problem.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/cavity_inverse_problem.py``
 		
 .. note::
 

--- a/docs/source/tutorial/spatial/stokes/nonnewton.rst
+++ b/docs/source/tutorial/spatial/stokes/nonnewton.rst
@@ -17,7 +17,9 @@ Since the problem is now strongly nonlinear, it is essential to provide a reason
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <stokes_nonnewtonian.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/stokes_nonnewtonian.py``
 		    

--- a/docs/source/tutorial/spatial/stokes/nonormalflow.rst
+++ b/docs/source/tutorial/spatial/stokes/nonormalflow.rst
@@ -63,7 +63,9 @@ The results are shown in :numref:`figspatialstokesnoflux`. It is apparent how th
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <stokes_no_normal_flow.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/stokes_no_normal_flow.py``
 		    

--- a/docs/source/tutorial/spatial/stokes/stokeslaw.rst
+++ b/docs/source/tutorial/spatial/stokes/stokeslaw.rst
@@ -136,7 +136,9 @@ The result is plotted in :numref:`figspatialstokeslaw`. We can easily change the
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <stokes_flow_around_object.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Spatial_PDEs/stokes_flow_around_object.py``
 		    

--- a/docs/source/tutorial/temporal/changeparams.rst
+++ b/docs/source/tutorial/temporal/changeparams.rst
@@ -81,7 +81,9 @@ Finally, if all simulations to be started are added, we can invoke the :py:meth:
 	
 	.. container:: downloadbutton
 
-		:download:`Download this example <parallel_running.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   		
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/parallel_running.py``
 

--- a/docs/source/tutorial/temporal/coupled.rst
+++ b/docs/source/tutorial/temporal/coupled.rst
@@ -36,9 +36,11 @@ Here, in particular the line
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <coupled_oscillators_method_1.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`    
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/coupled_oscillators_method_1.py``
 
 .. container:: center
 
@@ -68,9 +70,11 @@ In the definition of the problem, we can now combine two instances of the ``Sing
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <coupled_oscillators_method_2.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`    
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/coupled_oscillators_method_2.py``
 	
 
 .. container:: center
@@ -103,7 +107,9 @@ Also, the initial conditions are now separated, since initial conditions can onl
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <coupled_oscillators_method_3.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`    
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/coupled_oscillators_method_3.py``
 		

--- a/docs/source/tutorial/temporal/custommath/drivenho.rst
+++ b/docs/source/tutorial/temporal/custommath/drivenho.rst
@@ -37,6 +37,8 @@ The result is depicted in :numref:`figodetrapezoidaldriving`.
 	
 	.. container:: downloadbutton
 
-		:download:`Download this example <custom_math_driven_oscillator.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`  
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/custom_math_driven_oscillator.py``

--- a/docs/source/tutorial/temporal/custommath/tennis.rst
+++ b/docs/source/tutorial/temporal/custommath/tennis.rst
@@ -104,6 +104,8 @@ As a last note, we also can let the players move easily, since the positions of 
     
     .. container:: downloadbutton
 
-        :download:`Download this example <custom_math_dimensional_tennis.py>`
-        
-        :download:`Download all examples <../../tutorial_example_scripts.zip>`  
+        Full code available in the
+
+        :download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+        ``Temporal_ODEs/custom_math_dimensional_tennis.py``

--- a/docs/source/tutorial/temporal/lagrange.rst
+++ b/docs/source/tutorial/temporal/lagrange.rst
@@ -22,9 +22,11 @@ If you have read this tutorial until here, implementing this equation should be 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <pendulum_generalized_coordinate.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   		
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/pendulum_generalized_coordinate.py``
 
 However, in general, it is not always easy to find the generalized coordinate(s) for which the system automatically fulfills all imposed constraints. In that case, one still can enforce the constraints via Lagrange multipliers. In the given example of the pendulum, let us assume we were unable to find the generalized coordinate :math:`\phi` from the constraint :math:`g(x,y)`. We therefore would have to solve the full system, i.e. the equations of motion
 
@@ -102,9 +104,11 @@ Again, we make use of the :py:class:`~pyoomph.equations.generic.ODEObservables` 
 	
 	.. container:: downloadbutton
 
-		:download:`Download this example <pendulum_lagrange_multiplier.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   		
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/pendulum_lagrange_multiplier.py``
 
 
 

--- a/docs/source/tutorial/temporal/nondimho.rst
+++ b/docs/source/tutorial/temporal/nondimho.rst
@@ -85,6 +85,8 @@ By default, the output will be written to a sub-directory of the current directo
 
    .. container:: downloadbutton
 
-      :download:`Download this example <predefined_harmonic_oscillator.py>`
-      
-      :download:`Download all examples <../tutorial_example_scripts.zip>`
+      Full code available in the
+
+      :download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+      ``Temporal_ODEs/predefined_harmonic_oscillator.py``

--- a/docs/source/tutorial/temporal/nonlinho.rst
+++ b/docs/source/tutorial/temporal/nonlinho.rst
@@ -20,9 +20,11 @@ It is not a problem to add the nonlinear damping term to the residuals - a step 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <van_der_pol_method_1.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`    
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/van_der_pol_method_1.py``
 
 There is also another way to implement exactly the same equation by using already implemented equations. In the following, we make use of the predefined harmonic oscillator that comes with pyoomph:
 
@@ -50,6 +52,8 @@ If we replace :math:`\delta=-1/2 \mu(1-y)^2`, we get in fact the Van der Pol osc
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <van_der_pol_method_2.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/van_der_pol_method_2.py``

--- a/docs/source/tutorial/temporal/orbit/floquet.rst
+++ b/docs/source/tutorial/temporal/orbit/floquet.rst
@@ -67,9 +67,11 @@ For very large systems, where the monodromy matrix is too large to be assembled,
 
    .. container:: downloadbutton
 
-      :download:`Download this example <langford_floquet.py>`
-      
-      :download:`Download all examples <../../tutorial_example_scripts.zip>`
+      Full code available in the
+
+      :download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+      ``Temporal_ODEs/langford_floquet.py``
       
 
 Since the Floquet multipliers at :math:`\mu=2` cross the stability condition :math:`|\lambda|=1` by a complex-conjugated pair, this corresponds to a Neimark-Sacker bifurcation. The orbit becomes unstable to a torus. We can check this by performing time integration. The moment we leave the ``with`` statement of the ``orbit``, pyoomph will initialize the degrees of freedom to the starting point of the orbit. A trivial :py:meth:`~pyoomph.generic.problem.Problem.run` statement will then perform a time integration along the orbit. However, if we start at :math:`\mu>2` (here e.g. :math:`\mu=2.005`), it will be unstable and we can see the torus developing. We just have to replace the orbit loop (i.e. the code after solving for the Hopf bifurcation) by:
@@ -93,6 +95,8 @@ Since the Floquet multipliers at :math:`\mu=2` cross the stability condition :ma
 
    .. container:: downloadbutton
 
-      :download:`Download this example <langford_time_integration.py>`
-      
-      :download:`Download all examples <../../tutorial_example_scripts.zip>`
+      Full code available in the
+
+      :download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+      ``Temporal_ODEs/langford_time_integration.py``

--- a/docs/source/tutorial/temporal/orbit/hopf_switch.rst
+++ b/docs/source/tutorial/temporal/orbit/hopf_switch.rst
@@ -43,6 +43,8 @@ Eventually, a plot as shown in :numref:`fighopforbitslorenz` can be obtained, vi
 
    .. container:: downloadbutton
 
-      :download:`Download this example <hopf_switch.py>`
-      
-      :download:`Download all examples <../../tutorial_example_scripts.zip>`
+      Full code available in the
+
+      :download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+      ``Temporal_ODEs/hopf_switch.py``

--- a/docs/source/tutorial/temporal/orbit/manual_orbit.rst
+++ b/docs/source/tutorial/temporal/orbit/manual_orbit.rst
@@ -43,6 +43,8 @@ Since the guess is taken from a chaotic trajectory, which of the infinitely many
 
    .. container:: downloadbutton
 
-      :download:`Download this example <manual_orbit.py>`
-      
-      :download:`Download all examples <../../tutorial_example_scripts.zip>`
+      Full code available in the
+
+      :download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+      ``Temporal_ODEs/manual_orbit.py``

--- a/docs/source/tutorial/temporal/ownho.rst
+++ b/docs/source/tutorial/temporal/ownho.rst
@@ -55,6 +55,8 @@ The output is plotted in :numref:`fignondimhocustom`.
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <custom_harmonic_oscillator.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`    
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/custom_harmonic_oscillator.py``

--- a/docs/source/tutorial/temporal/stability/arclength.rst
+++ b/docs/source/tutorial/temporal/stability/arclength.rst
@@ -22,9 +22,11 @@ Obviously, there is no stationary solution for :math:`r<0`, whereas we have a st
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <bifurcation_fold_param_change.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/bifurcation_fold_param_change.py``
 		
                
 Of course, this code will crash the moment we decrease :math:`r<0`, since there is no stationary solution and hence :py:meth:`~pyoomph.generic.problem.Problem.solve` will fail. Since we know that the fold bifurcation takes place at :math:`r=0`, one could try to increase the parameter again after reaching :math:`r=0`, but then - which branch of the solution will be taken? The stable one at :math:`x=\sqrt{r}` or the unstable one at :math:`x=-\sqrt{r}`.
@@ -48,9 +50,11 @@ where :math:`(x^*,r^*)` is a starting point for which :math:`F(x^*,r^*)=0` holds
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <bifurcation_fold_arclength.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/bifurcation_fold_arclength.py``
 		
 
 First, reuse the classes from the beginning of this page, i.e. from :download:`bifurcation_fold_param_change.py`. We get a start solution :math:`(x^*,r^*)`. Then, we use :py:meth:`~pyoomph.generic.problem.Problem.arclength_continuation` to solve the system above for a step :math:`\Delta s`. In the first step the sign of :math:`\Delta s` (``ds`` in python here) gives the initial direction for the parameter, i.e. ``ds<0`` means we want to initially decrease the parameter :math:`r`. :py:meth:`~pyoomph.generic.problem.Problem.arclength_continuation` will now adjust :math:`r` and solve for the stationary solution at the same time. Furthermore, it returns a new guess for ``ds`` for the next step. In order to capture the curve well, we can add the optional argument ``max_ds`` to limit the maximum step along the tangential direction. After the first call of :py:meth:`~pyoomph.generic.problem.Problem.arclength_continuation`, the direction of the tangent and further parameters required for the next steps are implicitly stored in the :py:class:`~pyoomph.generic.problem.Problem` class. These are reset whenever one performs an :py:meth:`~pyoomph.generic.problem.Problem.arclength_continuation` with respect to another parameter or explicitly calls :py:meth:`~pyoomph.generic.problem.Problem.reset_arc_length_parameters`.
@@ -66,9 +70,11 @@ We can combine the :py:meth:`~pyoomph.generic.problem.Problem.arclength_continua
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <bifurcation_fold_arclength_eigen.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/bifurcation_fold_arclength_eigen.py``
 		
 
 

--- a/docs/source/tutorial/temporal/stability/biftrack.rst
+++ b/docs/source/tutorial/temporal/stability/biftrack.rst
@@ -94,8 +94,10 @@ The very same methods also work for spatio-temporal differential equations. An e
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <bifurcation_hopf_tracking_lorenz.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/bifurcation_hopf_tracking_lorenz.py``
 		
                

--- a/docs/source/tutorial/temporal/stability/branchswitch.rst
+++ b/docs/source/tutorial/temporal/stability/branchswitch.rst
@@ -119,6 +119,8 @@ The very same three methods, :py:meth:`~pyoomph.generic.problem.Problem.classify
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <bifurcation_branch_switching.py>`
+		Full code available in the
 
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/bifurcation_branch_switching.py``

--- a/docs/source/tutorial/temporal/stability/constraints.rst
+++ b/docs/source/tutorial/temporal/stability/constraints.rst
@@ -32,9 +32,11 @@ Indeed, the result is expected: A marginally stable solution at :math:`\phi=0` w
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <pendulum_gencoord_eigenvalues.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/pendulum_gencoord_eigenvalues.py``
 		
 
 Now, let's turn towards the system with the Lagrange multiplier. Naively, one might anticipate that we can find :math:`5` eigenvalues, since we have :math:`5` degrees of freedom. Let's see:
@@ -49,9 +51,11 @@ First, we use the fact that our system in :numref:`secODEpendulum` was already c
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <pendulum_lagrange_eigenvalues.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/pendulum_lagrange_eigenvalues.py``
 		
 
 While everything runs smoothly, instead of :math:`5` eigenvalues, only :math:`2` are returned, which are exactly the same as the ones in the simple system for the angle :math:`\phi` before. To see why this is the case and what is actually going on in pyoomph, we can go through the calculation of the eigenvalues analytically. First, the system is written as

--- a/docs/source/tutorial/temporal/stability/deflation.rst
+++ b/docs/source/tutorial/temporal/stability/deflation.rst
@@ -34,9 +34,11 @@ Depending on the generated random numbers, one either finds all three solutions 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <deflated_solve.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/deflated_solve.py``
 		
 
 Deflation can furthermore be combined with parameter scanning, in a sort of continuation. Opposed to arclength continuation, we do not solve along the arclength of a single solution branch, but just scan over the parameter branch once. But at each scanned parameter value, we try to find new solutions by deflation and try to connect the solutions at the previous parameter value to the new solutions. This algorithm has been proposed in Ref. :cite:`Farrell2016`, which can be invoked using the method :py:meth:`~pyoomph.generic.problem.Problem.deflated_continuation`:
@@ -65,7 +67,9 @@ We can indeed recover the diagram of the pitchfork normal form (cf. :numref:`fig
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <deflated_continuation.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/deflated_continuation.py``
 

--- a/docs/source/tutorial/temporal/stability/eigenvals.rst
+++ b/docs/source/tutorial/temporal/stability/eigenvals.rst
@@ -14,7 +14,9 @@ The rest is more or less the same as the previous code, i.e. first importing the
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <bifurcation_eigenvalues_transcritical.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/bifurcation_eigenvalues_transcritical.py``
 		

--- a/docs/source/tutorial/temporal/stability/globalparams.rst
+++ b/docs/source/tutorial/temporal/stability/globalparams.rst
@@ -56,7 +56,9 @@ After setting :math:`r=-1`, the dynamics of the system entirely changes. In part
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <bifurcation_transient_transcritical.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/bifurcation_transient_transcritical.py``
 		

--- a/docs/source/tutorial/temporal/stability/jumponbif.rst
+++ b/docs/source/tutorial/temporal/stability/jumponbif.rst
@@ -31,9 +31,11 @@ which yields for all :math:`v_\text{g}\neq 0` the known solution :math:`r_\text{
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <bifurcation_fold_tracking.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/bifurcation_fold_tracking.py``
 		
 
 The same works also for a pitchfork bifurcation, but these are subject to a symmetry, which is broken by the bifurcation. If we apply the fold tracking method to the pitchfork normal form :math:numref:`eqodepitchforknf`, we would get the augmented system

--- a/docs/source/tutorial/temporal/stability/lyapunov.rst
+++ b/docs/source/tutorial/temporal/stability/lyapunov.rst
@@ -72,8 +72,10 @@ The method described here can also be applied to spatio-temporal PDEs, which are
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <lorenz_lyapunov.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/lorenz_lyapunov.py``
 		
                

--- a/docs/source/tutorial/temporal/stability/stationary.rst
+++ b/docs/source/tutorial/temporal/stability/stationary.rst
@@ -22,7 +22,9 @@ Obviously, one can easily find a stationary solution by the :py:meth:`~pyoomph.g
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <bifurcation_stationary_transcritical.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/bifurcation_stationary_transcritical.py``
 		

--- a/docs/source/tutorial/temporal/timestepping/adaptivity.rst
+++ b/docs/source/tutorial/temporal/timestepping/adaptivity.rst
@@ -65,7 +65,9 @@ Note that also ``outstep=True`` was passed instead of ``numouts``. It will just 
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <adaptive_lorenz_attractor.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/adaptive_lorenz_attractor.py``
 		

--- a/docs/source/tutorial/temporal/timestepping/implicit.rst
+++ b/docs/source/tutorial/temporal/timestepping/implicit.rst
@@ -53,6 +53,8 @@ Finally, we let our script successively create a problem for each of the time st
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <oscillator_fully_implicit_schemes.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`     			
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/oscillator_fully_implicit_schemes.py``

--- a/docs/source/tutorial/temporal/timestepping/midpoint.rst
+++ b/docs/source/tutorial/temporal/timestepping/midpoint.rst
@@ -74,6 +74,8 @@ If :math:`\vec{F}` is linear, the midpoint rule and the trapezoidal rule are ide
 	
 	.. container:: downloadbutton
 
-		:download:`Download this example <oscillator_TPZ_scheme.py>`
-		
-		:download:`Download all examples <../../tutorial_example_scripts.zip>`   
+		Full code available in the
+
+		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/oscillator_TPZ_scheme.py``

--- a/docs/source/tutorial/temporal/timestepping/timescheme.rst
+++ b/docs/source/tutorial/temporal/timestepping/timescheme.rst
@@ -87,6 +87,8 @@ As a final note, other well-established methods, as e.g. the *Runge-Kutta method
     
     .. container:: downloadbutton
 
-        :download:`Download this example <time_stepping_schemes.py>`
-        
-        :download:`Download all examples <../../tutorial_example_scripts.zip>`   
+        Full code available in the
+
+        :download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`
+
+        ``Temporal_ODEs/time_stepping_schemes.py``

--- a/docs/source/tutorial/temporal/units.rst
+++ b/docs/source/tutorial/temporal/units.rst
@@ -58,6 +58,8 @@ Finally, instead of setting a scale at problem level, it is also possible to set
 
 	.. container:: downloadbutton
 
-		:download:`Download this example <dimensional_oscillator_with_units.py>`
-		
-		:download:`Download all examples <../tutorial_example_scripts.zip>`   	
+		Full code available in the
+
+		:download:`pyoomph example bundle <../tutorial_example_scripts.zip>`
+
+		``Temporal_ODEs/dimensional_oscillator_with_units.py``


### PR DESCRIPTION
## Download buttons

A tutorial script may `import` another one, so handing out a single `.py` file is not enough to actually run the example. All 131 download buttons (119 files) now name the script's path *inside* the bundle and link only `tutorial_example_scripts.zip`, which always works:

```rst
	.. container:: downloadbutton

		Full code available in the

		:download:`pyoomph example bundle <../../tutorial_example_scripts.zip>`

		``Spatial_PDEs/poisson_2d_adaptive.py``
```

The bundle paths are derived per file from `tutorial_bundle.CHAPTERS` — the same map that builds the zip — so they are the paths a reader actually finds after unpacking. `.downloadbutton` now uses `width: fit-content` (with `max-width: 100%`) instead of a fixed percentage, so the box follows its text.

## preCICE stub

`pyoomph/solvers/precice_adapter.py` imports `precice` at module level, and preCICE is deliberately not a documentation requirement. On Read the Docs that produced a warning per builder:

```
WARNING: Failed to import pyoomph.solvers.precice_adapter.
* ModuleNotFoundError: No module named 'precice'
```

The API page itself survived only by accident — `build_tutorial_zip()` puts `source/tutorial` on `sys.path`, and the tutorial chapter directory `source/tutorial/precice` is then picked up as a namespace package. That empty module has no `Participant`, so `sphinx_autodoc_typehints` could not evaluate `Problem._precice_interface`'s `"precice.Participant | None"` and gave up on the whole module: **every annotated `Problem` attribute lost its type cross-references on the published docs** (verified on the live page: 0 linked / 26 flat).

`conf.py` now stands a stub module in for preCICE when it is genuinely unavailable. Plain `autodoc_mock_imports = ["precice"]` fixes the warning but *not* the annotations, because that annotation cannot be evaluated against autodoc's `_MockObject` — measured with preCICE hidden:

| config | attribute annotations linked | flat |
| --- | --- | --- |
| nothing | 0 | 26 |
| `autodoc_mock_imports` | 0 | 26 |
| stub module | **25** | **0** |

The guard only stands in when preCICE is really missing (`spec.origin is None` also catches the namespace-package case), so a machine that has it keeps documenting the real package.

## Verification

Full HTML builds, with preCICE installed and with it hidden:

- **0 warnings** (was 1 per builder on RTD)
- `Problem` page back to 437 py-xrefs, 25 linked attribute annotations — identical to a build with real preCICE
- `precice_adapter` page complete (4 classes), tutorial links and viewcode page intact
- every API page byte-identical between the two builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cRxxDhMfcsHxx6JF5jnfj